### PR TITLE
find method fixed #1

### DIFF
--- a/ext/rbejdb/src/rbejdb.c
+++ b/ext/rbejdb/src/rbejdb.c
@@ -502,8 +502,8 @@ VALUE EJDB_find_internal(VALUE self, VALUE collName, VALUE queryWrap, VALUE q, V
 }
 
 VALUE EJDB_find_internal_wrapper(VALUE args) {
-    return EJDB_find_internal(rb_ary_pop(args), rb_ary_pop(args), rb_ary_pop(args),
-                              rb_ary_pop(args), rb_ary_pop(args), rb_ary_pop(args));
+    return EJDB_find_internal(rb_ary_entry(args, 0), rb_ary_entry(args, 1), rb_ary_entry(args, 2),
+                              rb_ary_entry(args, 3), rb_ary_entry(args, 4), rb_ary_entry(args, 5));
 }
 
 VALUE EJDB_find_ensure(VALUE queryWrap, VALUE exception) {

--- a/rbejdb.gemspec
+++ b/rbejdb.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |spec|
     --exclude .*\.o
     --exclude .*\.so
   ]
+  spec.add_development_dependency 'test-unit', '~> 3.0', '>= 3.1.2'
 end


### PR DESCRIPTION
Hello, 

I fixed the issue #1.  The rb_ary_pop function is not working as is expected in ruby 2.x.  So, I replaced this with the rb_ary_entry function  in the EJDB_find_internal_wrapper.  

I also added the test-unit dependency to the gemspec file. The tests passed.

I hope this be useful for others.

Cheerz
